### PR TITLE
Miscellaneous CLI fixes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,6 @@ jobs:
           deno-version: v2.x
       - run: deno fmt --check
       - run: deno lint
-      - run: deno task check
+      - run: deno check
       - run: deno test
       - run: deno publish --dry-run

--- a/backend.ts
+++ b/backend.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { clearAuthToken, exitBecauseNotLoggedIn, getAuthToken } from "./auth.ts";
+import { equal } from "@std/assert/equal";
 import { delay } from "@std/async/delay";
 import { zip } from "@std/collections/zip";
 import { GLUE_API_SERVER } from "./common.ts";
@@ -162,6 +163,9 @@ function areDeploymentsEqual(a: DeploymentDTO, b: DeploymentDTO): boolean {
     zip(a.buildSteps, b.buildSteps)
       .some(([stepA, stepB]) => stepA.name !== stepB.name || stepA.title !== stepB.title || stepA.status !== stepB.status)
   ) {
+    return false;
+  }
+  if (!equal(a.triggers, b.triggers) || !equal(a.accountInjections, b.accountInjections)) {
     return false;
   }
   return true;

--- a/commands/common.ts
+++ b/commands/common.ts
@@ -4,7 +4,7 @@ import { runStep } from "../ui/utils.ts";
 
 export async function askUserForGlue(): Promise<GlueDTO | undefined> {
   const glues = await runStep("Loading glues...", () => getGlues("deploy"));
-  if (!glues) {
+  if (!glues.length) {
     return undefined;
   }
   return await Select.prompt({

--- a/deno.json
+++ b/deno.json
@@ -8,7 +8,6 @@
   "tasks": {
     "cli": "deno run --allow-all glue.ts",
     "cli-debug": "deno run --inspect-brk --allow-all glue.ts dev samples/myExampleWebhook.ts --no-debug",
-    "check": "deno check **/*.ts*",
     "lint": "deno lint --watch",
     "test": "deno test --permit-no-files --watch"
   },

--- a/deno.json
+++ b/deno.json
@@ -6,13 +6,13 @@
     ".": "./glue.ts"
   },
   "tasks": {
-    "cli": "deno run --allow-all --unstable-temporal glue.ts",
-    "cli-debug": "deno run --inspect-brk --allow-all --unstable-temporal glue.ts dev samples/myExampleWebhook.ts --no-debug",
+    "cli": "deno run --allow-all glue.ts",
+    "cli-debug": "deno run --inspect-brk --allow-all glue.ts dev samples/myExampleWebhook.ts --no-debug",
     "check": "deno check **/*.ts*",
     "lint": "deno lint --watch",
     "test": "deno test --permit-no-files --watch"
   },
-  "unstable": ["kv"],
+  "unstable": ["kv", "temporal"],
   "imports": {
     "@cliffy/command": "jsr:@cliffy/command@1.0.0-rc.7",
     "@cliffy/prompt": "jsr:@cliffy/prompt@1.0.0-rc.7",


### PR DESCRIPTION
- Some deno.json cleanup
- Correctly show an error on subcommands that try to list glues when you have no glues.
- Fix issue where individual triggers and injections don't show as configured until you've configured all of them.