### PR TITLE
use Deno's `--watch` flag and avoid orphaned glue processes

### DIFF
--- a/commands/dev.ts
+++ b/commands/dev.ts
@@ -36,14 +36,14 @@ let lastMessage: ServerWebsocketMessage | undefined;
 export async function dev(options: DevOptions, filename: string) {
   await checkForAuthCredsOtherwiseExit();
 
-  let lifelifeHasConnected = false;
+  let lifelineHasConnected = false;
   const lifelineFirstConnectionDeferred = Promise.withResolvers<void>();
   const lifelineReconnectionEvents = pushableV<void>({ objectMode: true });
 
   const glueName = options.name ?? glueNameFromFilename(filename);
   const glueCliWebsocketAddr = await wsListen(() => {
-    if (!lifelifeHasConnected) {
-      lifelifeHasConnected = true;
+    if (!lifelineHasConnected) {
+      lifelineHasConnected = true;
       lifelineFirstConnectionDeferred.resolve();
     } else {
       lifelineReconnectionEvents.push();

--- a/deno.json
+++ b/deno.json
@@ -32,6 +32,7 @@
     "hono": "npm:hono@^4.7.5",
     "ink": "npm:ink@^5.1.1",
     "ink-spinner": "npm:ink-spinner@^5.0.0",
+    "it-pushable": "npm:it-pushable@^3.2.3",
     "react": "npm:react@^18.3.1",
     "zod": "npm:zod@^3.24.0",
     "@std/fmt": "jsr:@std/fmt@^1.0.3",

--- a/deno.json
+++ b/deno.json
@@ -28,7 +28,7 @@
     "@std/net": "jsr:@std/net@^1.0.4",
     "@std/path": "jsr:@std/path@^1.0.8",
     "@std/streams": "jsr:@std/streams@^1.0.9",
-    "@streak-glue/runtime": "jsr:@streak-glue/runtime@^0.2.0",
+    "@streak-glue/runtime": "jsr:@streak-glue/runtime@^0.2.1",
     "hono": "npm:hono@^4.7.5",
     "ink": "npm:ink@^5.1.1",
     "ink-spinner": "npm:ink-spinner@^5.0.0",

--- a/deno.lock
+++ b/deno.lock
@@ -9,7 +9,7 @@
     "jsr:@cliffy/keypress@1.0.0-rc.7": "1.0.0-rc.7",
     "jsr:@cliffy/prompt@1.0.0-rc.7": "1.0.0-rc.7",
     "jsr:@cliffy/table@1.0.0-rc.7": "1.0.0-rc.7",
-    "jsr:@hono/hono@^4.7.4": "4.9.7",
+    "jsr:@hono/hono@^4.7.4": "4.9.8",
     "jsr:@opensrc/deno-open@1": "1.0.0",
     "jsr:@std/assert@1": "1.0.14",
     "jsr:@std/assert@~0.218.2": "0.218.2",
@@ -34,8 +34,8 @@
     "jsr:@std/path@~1.0.6": "1.0.9",
     "jsr:@std/streams@^1.0.9": "1.0.11",
     "jsr:@std/text@~1.0.7": "1.0.15",
-    "jsr:@streak-glue/runtime@*": "0.2.0",
-    "jsr:@streak-glue/runtime@0.2": "0.2.0",
+    "jsr:@streak-glue/runtime@*": "0.2.1",
+    "jsr:@streak-glue/runtime@~0.2.1": "0.2.1",
     "npm:@googleapis/gmail@14": "14.0.1",
     "npm:@octokit/webhooks-types@^7.6.1": "7.6.1",
     "npm:@types/node@*": "24.2.0",
@@ -107,8 +107,8 @@
         "jsr:@std/fmt@~1.0.2"
       ]
     },
-    "@hono/hono@4.9.7": {
-      "integrity": "5293d82fc6d25782ff9e0a89680f99cdd27ed19eb0558e2786c22a46a4594424"
+    "@hono/hono@4.9.8": {
+      "integrity": "908150f13e90181a051a3af3bf15203aff00190682afedfd38824d0cb9299a95"
     },
     "@opensrc/deno-open@1.0.0": {
       "integrity": "590decada8cf2d50f4b35c7d3a8d642e18e45d6e47078ea02a4dbf0096bbf9fd",
@@ -186,8 +186,8 @@
     "@std/text@1.0.15": {
       "integrity": "91f5cc1e12779a3d95f1be34e763f9c28a75a078b7360e6fcaef0d8d9b1e3e7f"
     },
-    "@streak-glue/runtime@0.2.0": {
-      "integrity": "53204ec82dde04e6afdec7517611e45851952e07653875f16a21d810c289a066",
+    "@streak-glue/runtime@0.2.1": {
+      "integrity": "656ab16194c151dfe716957a28ecbe02a915a2230c30f6c7498da799b0bc5c69",
       "dependencies": [
         "jsr:@hono/hono",
         "npm:@octokit/webhooks-types",
@@ -780,7 +780,7 @@
       "jsr:@std/net@^1.0.4",
       "jsr:@std/path@^1.0.8",
       "jsr:@std/streams@^1.0.9",
-      "jsr:@streak-glue/runtime@0.2",
+      "jsr:@streak-glue/runtime@~0.2.1",
       "npm:@types/react@18",
       "npm:hono@^4.7.5",
       "npm:ink-spinner@5",

--- a/deno.lock
+++ b/deno.lock
@@ -45,6 +45,7 @@
     "npm:hono@^4.7.5": "4.9.4",
     "npm:ink-spinner@5": "5.0.0_ink@5.2.1__@types+react@18.3.24__react@18.3.1_react@18.3.1_@types+react@18.3.24",
     "npm:ink@^5.1.1": "5.2.1_@types+react@18.3.24_react@18.3.1",
+    "npm:it-pushable@^3.2.3": "3.2.3",
     "npm:react@^18.3.1": "18.3.1",
     "npm:stripe@^18.2.0": "18.5.0_@types+node@24.2.0",
     "npm:zod@^3.24.0": "3.25.76",
@@ -534,6 +535,12 @@
       "integrity": "sha512-eUuAjybVTHMYWm/U+vBO1sY/JOCgoPCXRxzdju0K+K0BiGW0SChEL1MLC0PoCIR1OlPo5YAp8HuQoUlsWEICwg==",
       "bin": true
     },
+    "it-pushable@3.2.3": {
+      "integrity": "sha512-gzYnXYK8Y5t5b/BnJUr7glfQLO4U5vyb05gPx/TyTw+4Bv1zM9gFk4YsOrnulWefMewlphCjKkakFvj1y99Tcg==",
+      "dependencies": [
+        "p-defer"
+      ]
+    },
     "js-tokens@4.0.0": {
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
@@ -597,6 +604,9 @@
       "dependencies": [
         "mimic-fn"
       ]
+    },
+    "p-defer@4.0.1": {
+      "integrity": "sha512-Mr5KC5efvAK5VUptYEIopP1bakB85k2IWXaRC0rsh1uwn1L6M0LVml8OIQ4Gudg4oyZakf7FmeRLkMMtZW1i5A=="
     },
     "patch-console@2.0.0": {
       "integrity": "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA=="
@@ -785,6 +795,7 @@
       "npm:hono@^4.7.5",
       "npm:ink-spinner@5",
       "npm:ink@^5.1.1",
+      "npm:it-pushable@^3.2.3",
       "npm:react@^18.3.1",
       "npm:zod@^3.24.0"
     ]


### PR DESCRIPTION
Use Deno's `--watch` flag and avoid orphaned glue processes. Makes use of https://github.com/StreakYC/glue-runtime/pull/9.

<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-18 22:28:16 UTC

This PR introduces a significant architectural improvement to the `glue dev` command by replacing custom file watching with Deno's built-in `--watch` flag and implementing a WebSocket-based "lifeline" system to prevent orphaned processes. 

The key changes include:

- **Removed custom file watching**: The previous implementation used a file watcher with debouncing that only monitored the main glue file, missing changes in imported dependencies. This has been replaced with Deno's `--watch` flag which automatically detects changes across the entire dependency tree.

- **Added WebSocket lifeline system**: A new WebSocket server is created that spawned glue processes connect to. This creates a "lifeline" connection that ensures child processes terminate when the CLI exits, preventing orphaned processes that could continue running indefinitely.

- **Simplified process management**: The complex health check retry mechanism and manual restart logic has been removed. Instead, the system relies on Deno's native restart capabilities triggered by file changes, with the CLI listening for reconnection events when processes restart.

- **Updated dependencies**: The `@streak-glue/runtime` dependency is bumped from 0.2.0 to 0.2.1 (incorporating improvements from glue-runtime PR #9), and `it-pushable` 3.2.3 is added to handle async iterable events for lifeline reconnections.

This change addresses two critical limitations mentioned in the original TODO comments: incomplete dependency watching and the risk of orphaned subprocesses. The new architecture leverages Deno's native capabilities rather than custom implementations, resulting in more robust process lifecycle management that integrates seamlessly with the existing CLI workflow.

## Confidence score: 4/5

- This PR introduces significant architectural changes that improve process management but requires careful testing of the WebSocket lifeline system
- Score reflects solid implementation with good error handling, though the WebSocket-based approach adds complexity that needs validation
- Pay close attention to the WebSocket server implementation in `commands/dev.ts` and ensure the lifeline connection logic works reliably across different scenarios

<!-- /greptile_comment -->