### PR TITLE
When not using deno.json, ensure latest glue-runtime is used

### DIFF
--- a/commands/dev.ts
+++ b/commands/dev.ts
@@ -29,7 +29,7 @@ import {
   TriggerEvent,
   type TriggerRegistration,
 } from "@streak-glue/runtime/backendTypes";
-import { type Awaitable, GLUE_API_SERVER } from "../common.ts";
+import { type Awaitable, GLUE_API_SERVER, GLUE_RUNTIME_PACKAGE } from "../common.ts";
 import { equal } from "@std/assert/equal";
 import { delay } from "@std/async/delay";
 import { keypress, type KeyPressEvent } from "@cliffy/keypress";
@@ -41,6 +41,7 @@ import { getGlueName } from "../lib/glueNaming.ts";
 import { getOutdatedStreakRuntimeVersion } from "../lib/runtimeVersionCheck.ts";
 import { once } from "node:events";
 import type { CommonCommandOptions } from "./common.ts";
+import { findDenoConfigPaths } from "../lib/denoConfig.ts";
 
 const GLUE_DEV_PORT = getAvailablePort({ preferredPort: 8001 });
 const DEFAULT_DEBUG_PORT = 9229;
@@ -75,7 +76,7 @@ export async function dev(options: DevOptions, filename: string) {
     const lifelineReconnectionEvents = pushableV<void>({ objectMode: true });
 
     const glueName = await getGlueName(filename, options.name);
-    await warnIfStreakRuntimeIsOutdated(filename, options.verbose);
+    const reloadStreakRuntime = await streakRuntimeUpdateChecks(filename, options.verbose);
 
     const glueCliWebsocketAddr = await wsListen(() => {
       if (!lifelineHasConnected) {
@@ -112,7 +113,13 @@ export async function dev(options: DevOptions, filename: string) {
     }
 
     await runUIStep("bootingCode", async () => {
-      const c = spawnLocalGlueProcess(filename, env, debugMode, abortController);
+      const c = spawnLocalGlueProcess(
+        filename,
+        env,
+        debugMode,
+        abortController,
+        reloadStreakRuntime,
+      );
 
       const unsub = new AbortController();
       try {
@@ -511,19 +518,38 @@ function analyzeCode(_filename: string): AnalysisResult {
   return { errors: [] };
 }
 
-async function warnIfStreakRuntimeIsOutdated(filename: string, verbose: boolean): Promise<void> {
+/**
+ * @returns true if the glue process should be started with the `--reload` flag
+ * to ensure the latest version of the streak runtime is used, false otherwise.
+ */
+async function streakRuntimeUpdateChecks(filename: string, verbose: boolean): Promise<boolean> {
   try {
-    const outdatedRuntime = await getOutdatedStreakRuntimeVersion(filename);
-    if (!outdatedRuntime) {
-      return;
+    const denoConfigPaths = await findDenoConfigPaths(path.dirname(filename));
+    if (!denoConfigPaths.denoJsonPath) {
+      // When not using deno.json/deno.lock, we want to make sure unversioned
+      // imports for "jsr:@streak-glue/runtime" get the latest version. We could
+      // issue some Deno command to update the cache with the latest version
+      // before we run the user's glue, but instead we'll just pass "--reload"
+      // to the user's glue Deno process.
+      return true;
+    } else {
+      // When using deno.json+deno.lock, check if the @streak-glue/runtime
+      // version is outdated and warn the user if so.
+      const outdatedRuntime = await getOutdatedStreakRuntimeVersion(filename, denoConfigPaths);
+      if (!outdatedRuntime) {
+        return false;
+      }
+      devProgressProps.outdatedRuntimeWarningInfo = outdatedRuntime;
+      renderUI();
+      return false;
     }
-    devProgressProps.outdatedRuntimeWarningInfo = outdatedRuntime;
-    renderUI();
   } catch (e) {
     if (verbose) {
       console.error("Caught error:", e);
     }
   }
+
+  return false;
 }
 
 async function discoverRegistrations(signal?: AbortSignal): Promise<Registrations> {
@@ -546,6 +572,7 @@ function spawnLocalGlueProcess(
   env: Record<string, string>,
   debugMode: DebugMode,
   abortController: AbortController,
+  reloadStreakRuntime: boolean,
 ) {
   abortController.signal.throwIfAborted();
 
@@ -561,6 +588,9 @@ function spawnLocalGlueProcess(
   ];
   if (debugMode !== "no-debug") {
     flags.push("--" + debugMode);
+  }
+  if (reloadStreakRuntime) {
+    flags.push(`--reload=jsr:${GLUE_RUNTIME_PACKAGE}`);
   }
 
   const command = new Deno.Command(Deno.execPath(), {

--- a/lib/runtimeVersionCheck.test.ts
+++ b/lib/runtimeVersionCheck.test.ts
@@ -66,8 +66,10 @@ Deno.test("getOutdatedStreakRuntimeVersion returns latest mismatch and formats w
       },
     }),
   );
+  const denoConfigPaths = await findDenoConfigPaths(sourceDir);
   const outdatedInfo = await getOutdatedStreakRuntimeVersion(
     filename,
+    denoConfigPaths,
     () =>
       Promise.resolve(
         new Response(JSON.stringify({ scope: "@streak-glue", name: "runtime", latest: "0.2.33" }), {

--- a/lib/runtimeVersionCheck.ts
+++ b/lib/runtimeVersionCheck.ts
@@ -1,6 +1,5 @@
-import * as path from "@std/path";
 import z from "zod";
-import { findDenoConfigPaths } from "./denoConfig.ts";
+import type { DenoConfigPaths } from "./denoConfig.ts";
 import { GLUE_RUNTIME_PACKAGE } from "../common.ts";
 
 const GLUE_RUNTIME_JSR_SPECIFIER = `jsr:${GLUE_RUNTIME_PACKAGE}`;
@@ -12,15 +11,15 @@ export interface OutdatedRuntimeInfo {
 }
 
 export async function getOutdatedStreakRuntimeVersion(
-  filename: string,
+  _filename: string,
+  denoConfigPaths: DenoConfigPaths,
   fetchImpl: typeof fetch = fetch,
 ): Promise<OutdatedRuntimeInfo | undefined> {
-  const { denoLockPath } = await findDenoConfigPaths(path.dirname(filename));
-  if (!denoLockPath) {
+  if (!denoConfigPaths.denoLockPath) {
     return undefined;
   }
   const currentVersion = extractStreakRuntimeVersionFromDenoLockText(
-    await Deno.readTextFile(denoLockPath),
+    await Deno.readTextFile(denoConfigPaths.denoLockPath),
   );
   if (!currentVersion) {
     return undefined;


### PR DESCRIPTION
Follow-up to https://github.com/StreakYC/glue-cli/pull/30, which applies specifically for Glues that have a deno.json and shows a warning message if an old glue-runtime is being used.

This PR applies to Glues without a deno.json. It causes us to run the user's glue with the right Deno flags to ensure unversioned glue-runtime imports use the latest version.