### PR TITLE
glue login and create command tweaks

### DIFF
--- a/commands/create.ts
+++ b/commands/create.ts
@@ -19,8 +19,8 @@ export async function create(_options: CommonCommandOptions) {
     default: DEFAULT_FILENAME,
   });
   const code = TEMPLATE_CONTENT;
-  filename = await uniquifyPath(filename);
   filename = appendFileExtensionIfNotPresent(filename, ".ts");
+  filename = await uniquifyPath(filename);
   await Deno.writeTextFile(filename, code, { createNew: true });
   console.log(`${green("✔︎")} Successfully created new glue file: ${bold(filename)}`);
 

--- a/commands/create.ts
+++ b/commands/create.ts
@@ -32,25 +32,7 @@ export async function create(_options: CommonCommandOptions) {
   return filename;
 }
 
-interface Editor {
-  name: string;
-  command: string;
-  installPage: string;
-  macOSDownloadUrl: string;
-}
-
-const VSCode: Editor = {
-  name: "VSCode",
-  command: "code",
-  installPage: "https://code.visualstudio.com/download",
-  macOSDownloadUrl: "https://code.visualstudio.com/download",
-};
-const Cursor: Editor = {
-  name: "Cursor",
-  command: "cursor",
-  installPage: "https://cursor.com/download",
-  macOSDownloadUrl: "https://cursor.sh",
-};
+const defaultEditors = ["cursor", "code", "zed"];
 
 async function openInEditorFlow(filename: string) {
   const editor = await detectPreferredAndInstalledEditor();
@@ -60,7 +42,7 @@ async function openInEditorFlow(filename: string) {
 
   console.log();
   const openInEditor = await Confirm.prompt({
-    message: "Open created glue in editor?",
+    message: `Open created glue in editor? (Detected: ${editor})`,
     default: true,
   });
 
@@ -69,36 +51,31 @@ async function openInEditorFlow(filename: string) {
   }
 }
 
-async function detectPreferredAndInstalledEditor(): Promise<Editor | undefined> {
+async function detectPreferredAndInstalledEditor(): Promise<string | undefined> {
   const editorEnv = Deno.env.get("EDITOR");
   const firstTerm = editorEnv?.split(/\s+/)[0];
-  if (firstTerm === VSCode.command) {
-    return VSCode;
+  if (firstTerm && defaultEditors.includes(firstTerm)) {
+    return firstTerm;
   }
-  if (firstTerm === Cursor.command) {
-    return Cursor;
-  }
-
-  if (await isEditorInstalled(Cursor)) {
-    return Cursor;
-  }
-  if (await isEditorInstalled(VSCode)) {
-    return VSCode;
+  for (const cmd of defaultEditors) {
+    if (await isEditorInstalled(cmd)) {
+      return cmd;
+    }
   }
   return undefined;
 }
 
-async function isEditorInstalled(editor: Editor): Promise<boolean> {
+async function isEditorInstalled(editorCommand: string): Promise<boolean> {
   try {
-    await new Deno.Command(editor.command, { args: ["--version"] }).output();
+    await new Deno.Command(editorCommand, { args: ["--version"] }).output();
     return true;
   } catch (_error) {
     return false;
   }
 }
 
-async function openEditor(editor: Editor, filename: string): Promise<void> {
-  await new Deno.Command(editor.command, { args: [filename] }).output();
+async function openEditor(editorCommand: string, filename: string): Promise<void> {
+  await new Deno.Command(editorCommand, { args: [filename] }).output();
 }
 
 function appendFileExtensionIfNotPresent(filename: string, extension: string): string {

--- a/commands/create.ts
+++ b/commands/create.ts
@@ -37,6 +37,12 @@ const defaultEditors = ["cursor", "code", "zed"];
 async function openInEditorFlow(filename: string) {
   const editor = await detectPreferredAndInstalledEditor();
   if (!editor) {
+    console.log();
+    console.log("Couldn't detect a preferred IDE installed on your system.");
+    console.log("You may open the created glue file in any text editor.");
+    console.log(
+      "We recommend using an IDE such as Cursor (https://cursor.com/) or\nVisual Studio Code (https://code.visualstudio.com/).",
+    );
     return;
   }
 

--- a/commands/create.ts
+++ b/commands/create.ts
@@ -1,9 +1,7 @@
-import { blue, bold, green } from "@std/fmt/colors";
+import { bold, green } from "@std/fmt/colors";
 import { Input } from "@cliffy/prompt/input";
 import * as path from "@std/path";
 import { Confirm } from "@cliffy/prompt/confirm";
-import { delay } from "@std/async/delay";
-import { Spinner } from "@std/cli/unstable-spinner";
 import { promptToInstallSkills } from "./skills.ts";
 import type { CommonCommandOptions } from "./common.ts";
 
@@ -55,6 +53,11 @@ const Cursor: Editor = {
 };
 
 async function openInEditorFlow(filename: string) {
+  const editor = await detectPreferredAndInstalledEditor();
+  if (!editor) {
+    return;
+  }
+
   console.log();
   const openInEditor = await Confirm.prompt({
     message: "Open created glue in editor?",
@@ -62,18 +65,6 @@ async function openInEditorFlow(filename: string) {
   });
 
   if (openInEditor) {
-    let editor = await detectPreferredAndInstalledEditor();
-    if (!editor) {
-      const installCursor = await Confirm.prompt({
-        message: "No editors found, install Cursor (recommended)?",
-        default: true,
-      });
-      if (!installCursor) {
-        return;
-      }
-      await installEditor(Cursor);
-      editor = Cursor;
-    }
     await openEditor(editor, filename);
   }
 }
@@ -104,30 +95,6 @@ async function isEditorInstalled(editor: Editor): Promise<boolean> {
   } catch (_error) {
     return false;
   }
-}
-
-async function installEditor(editor: Editor): Promise<void> {
-  if (Deno.build.os == "darwin") {
-    // TODO in the future we may install for the user
-    console.log(`Download and ${editor.name} install from: ${blue(bold(editor.installPage))}`);
-  } else {
-    console.log(`Download and ${editor.name} install from: ${blue(bold(editor.installPage))}`);
-  }
-
-  const spinner = new Spinner({
-    message: `Waiting for ${editor.name} to be installed...`,
-  });
-  spinner.start();
-
-  while (true) {
-    try {
-      await new Deno.Command(editor.command, { args: ["--version"] }).output();
-      break;
-    } catch (_e) {
-      await delay(1000);
-    }
-  }
-  spinner.stop();
 }
 
 async function openEditor(editor: Editor, filename: string): Promise<void> {

--- a/commands/create.ts
+++ b/commands/create.ts
@@ -14,8 +14,6 @@ glue.webhook.onGet((_event) => {
 `;
 
 export async function create(_options: CommonCommandOptions) {
-  await promptToInstallSkills();
-
   let filename = await Input.prompt({
     message: "Enter the filename for the new glue",
     default: DEFAULT_FILENAME,
@@ -25,6 +23,8 @@ export async function create(_options: CommonCommandOptions) {
   filename = appendFileExtensionIfNotPresent(filename, ".ts");
   await Deno.writeTextFile(filename, code);
   console.log(`${green("✔︎")} Successfully created new glue file: ${bold(filename)}`);
+
+  await promptToInstallSkills();
 
   await openInEditorFlow(filename);
   console.log();

--- a/commands/create.ts
+++ b/commands/create.ts
@@ -21,7 +21,7 @@ export async function create(_options: CommonCommandOptions) {
   const code = TEMPLATE_CONTENT;
   filename = await uniquifyPath(filename);
   filename = appendFileExtensionIfNotPresent(filename, ".ts");
-  await Deno.writeTextFile(filename, code);
+  await Deno.writeTextFile(filename, code, { createNew: true });
   console.log(`${green("✔︎")} Successfully created new glue file: ${bold(filename)}`);
 
   await promptToInstallSkills();

--- a/commands/login.ts
+++ b/commands/login.ts
@@ -39,5 +39,8 @@ export const login = async () => {
   await open(loginUrl);
 
   await server.finished;
-  console.log(`\n💡 Run ${mod.green("glue create")} to create your first glue`);
+  console.log(`\n💡 Run ${mod.green("glue create")} to create your first glue.`);
+  console.log(
+    `💡 Run ${mod.green("glue install-skills")} to teach your local coding agents how to use Glue.`,
+  );
 };

--- a/commands/skills.ts
+++ b/commands/skills.ts
@@ -69,6 +69,10 @@ export async function installSkills(): Promise<void> {
   );
 }
 
+/**
+ * Called at the end of `glue create` to offer to install the Glue skill if we
+ * detect a supported agent is installed.
+ */
 export async function promptToInstallSkills(): Promise<void> {
   const home = requireHomeDirectory();
 

--- a/commands/skills.ts
+++ b/commands/skills.ts
@@ -87,6 +87,10 @@ export async function promptToInstallSkills(): Promise<void> {
     return;
   }
 
+  console.log();
+  console.log(
+    "We noticed you have Codex or Claude Code installed but don't have the Glue skill installed for them.",
+  );
   const shouldInstall = await Confirm.prompt({
     message: "Install the Glue agent skill for Codex or Claude Code now?",
     default: true,


### PR DESCRIPTION
- After logging in, suggest `glue install-skills` command alongside the existing `glue create` suggestion.
- Fixed bug in `glue create` that allowed it to overwrite an existing glue.
- If `glue create` doesn't detect any editors, have a better simpler flow suggesting our recommended editors to the user.
- In `glue create`, suggest installing agent skills after setting up the new glue.